### PR TITLE
Drop Windows 2016 and VS 2017

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,7 +11,6 @@ build: off
 skip_branch_with_pr: true
 
 image:
-  - Visual Studio 2017
   - Visual Studio 2019
   - Ubuntu1804
   - macos
@@ -20,26 +19,10 @@ for:
 -
   matrix:
     only:
-      - image: Visual Studio 2017
-  install:
-    - choco install -y dotnet-sdk --version=5.0.400
-    - choco install -y tapwindows
-    - choco install -y procdump
-    - ps: .\scripts\InstallNpcap.ps1
-    - ps: .\scripts\install-winpkfilter.ps1
-  build_script:
-    - dotnet build -c Release
-  test_script:
-    - bash scripts/test.sh --filter "TestCategory!=Performance&TestCategory!=RemotePcap&TestCategory!=WinDivert&TestCategory!=WinpkFilter"
-
--
-  matrix:
-    only:
       - image: Visual Studio 2019
   install:
-    - choco install -y tapwindows
-    - choco install -y procdump
-    - ps: .\scripts\InstallNpcap.ps1
+    - ps: .\scripts\install-windows.ps1
+    - ps: .\scripts\Install-npcap.ps1
     - ps: .\scripts\install-winpkfilter.ps1
   build_script:
     - dotnet build -c Release

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,13 +33,27 @@ jobs:
     env:
       CODECOV_TOKEN: $(CODECOV_TOKEN)
 
-- job: windows_2016_vs2017_npcap
+# NOTE: Remove when npcap has rpcapd support
+- job: windows_2019_winpcap
   pool:
-    vmImage: 'VS2017-Win2016'
+    vmImage: 'windows-2019'
   steps:
-  - script: choco install -y tapwindows
-  - script: choco install -y procdump
-  - pwsh: ./scripts/InstallNpcap.ps1
+  # tap windows have to be installed before winpcap,
+  # otherwise winpcap will only pick it up after reboot
+  - pwsh: .\scripts\install-windows.ps1
+  - script: choco install -y winpcap
+  - pwsh: .\scripts\install-winpkfilter.ps1
+  - script: dotnet restore -s https://api.nuget.org/v3/index.json
+  - script: bash scripts/test.sh --filter "TestCategory!=Timestamp"
+    env:
+      CODECOV_TOKEN: $(CODECOV_TOKEN)
+
+- job: windows_2019_npcap
+  pool:
+    vmImage: windows-2019
+  steps:
+  - pwsh: ./scripts/Install-windows.ps1
+  - pwsh: ./scripts/Install-npcap.ps1
     env:
       npcap_oem_key: $(npcap_oem_key)
   - pwsh: .\scripts\install-winpkfilter.ps1
@@ -48,28 +62,12 @@ jobs:
     env:
       CODECOV_TOKEN: $(CODECOV_TOKEN)
 
-# NOTE: Remove when npcap has rpcapd support
-- job: windows_2019_vs2019_winpcap
+- job: windows_2022_npcap
   pool:
-    vmImage: 'windows-2019'
+    vmImage: windows-2022
   steps:
-  # tap windows have to be installed before winpcap,
-  # otherwise winpcap will only pick it up after reboot
-  - script: choco install -y tapwindows
-  - script: choco install -y procdump
-  - script: choco install -y winpcap
-  - pwsh: .\scripts\install-winpkfilter.ps1
-  - script: dotnet restore -s https://api.nuget.org/v3/index.json
-  - script: bash scripts/test.sh --filter "TestCategory!=Timestamp"
-    env:
-      CODECOV_TOKEN: $(CODECOV_TOKEN)
-
-- job: windows_2019_vs2019_npcap
-  pool:
-    vmImage: 'windows-2019'
-  steps:
-  - script: choco install -y tapwindows
-  - pwsh: ./scripts/InstallNpcap.ps1
+  - pwsh: ./scripts/Install-windows.ps1
+  - pwsh: ./scripts/Install-npcap.ps1
     env:
       npcap_oem_key: $(npcap_oem_key)
   - pwsh: .\scripts\install-winpkfilter.ps1

--- a/scripts/Install-npcap.ps1
+++ b/scripts/Install-npcap.ps1
@@ -2,7 +2,7 @@
 # Copied from https://github.com/secdev/scapy/blob/master/.config/appveyor/InstallNpcap.ps1
 
 # Config:
-$npcap_oem_file = "npcap-1.20-oem.exe"
+$npcap_oem_file = "npcap-1.55-oem.exe"
 
 # Note: because we need the /S option (silent), this script has two cases:
 #  - The script is runned from a master build, then use the secure variable 'npcap_oem_key' which will be available

--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -1,0 +1,4 @@
+
+choco install -y dotnet-sdk --version=5.0.403
+choco install -y tapwindows
+choco install -y procdump


### PR DESCRIPTION
# Drop Windows 2016
* Dropped by Microsoft, see https://github.com/actions/virtual-environments/issues/4312

# Drop Visual Studio 2017
* With the introduction of VS2022, it makes no sense ton invest time on VS2017 anymore
* VS2017 "Mainstream End Date" is Apr 12, 2022, See https://docs.microsoft.com/en-us/lifecycle/products/visual-studio-2017