### PR TITLE
Add support for reading capture data from a file handle

### DIFF
--- a/SharpPcap/LibPcap/CaptureFileReaderDevice.cs
+++ b/SharpPcap/LibPcap/CaptureFileReaderDevice.cs
@@ -27,7 +27,7 @@ namespace SharpPcap.LibPcap
     /// <summary>
     /// Read a pcap capture file
     /// </summary>
-    public class CaptureFileReaderDevice : PcapDevice
+    public class CaptureFileReaderDevice : CaptureReaderDevice
     {
         private readonly string m_pcapFile;
 
@@ -128,17 +128,6 @@ namespace SharpPcap.LibPcap
 
             base.Open(configuration);
         }
-
-        /// <summary>
-        /// Retrieves pcap statistics
-        ///
-        /// Not currently supported for this device
-        /// </summary>
-        /// <returns>
-        /// A <see cref="PcapStatistics"/>
-        /// </returns>
-        public override ICaptureStatistics Statistics => null;
-
     }
 }
 

--- a/SharpPcap/LibPcap/CaptureHandleReaderDevice.cs
+++ b/SharpPcap/LibPcap/CaptureHandleReaderDevice.cs
@@ -1,0 +1,93 @@
+/*
+This file is part of SharpPcap.
+
+SharpPcap is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+SharpPcap is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with SharpPcap.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace SharpPcap.LibPcap
+{
+    /// <summary>
+    /// Read a pcap capture from a file handle (e.g., a pipe).
+    ///
+    /// NOTE: libpcap will take ownership of the handle. The handle will be closed when this device is closed.
+    /// On non-Windows systems, the handle passed to this class MUST be opened by <c>fopen</c> or similar functions
+    /// that return a <c>FILE*</c> (e.g., via Mono.Posix.NETStandard).
+    /// </summary>
+    public class CaptureHandleReaderDevice : CaptureReaderDevice
+    {
+        /// <value>
+        /// File handle the object was created with.
+        /// </value>
+        public SafeHandle FileHandle { get; }
+
+        /// <value>
+        /// The name of the capture file.
+        /// </value>
+        public override string Name => "<file handle>";
+
+        /// <value>
+        /// Description of the device.
+        /// </value>
+        public override string Description => "Capture handle reader device";
+
+        /// <summary>
+        /// Creates a new <c>CaptureHandleReaderDevice</c>.
+        /// </summary>
+        /// <param name="handle">
+        /// On Windows, a native Windows handle. On other systems, a pointer to a C runtime <c>FILE</c> object.
+        /// </param>
+        public CaptureHandleReaderDevice(SafeHandle handle)
+        {
+            FileHandle = handle;
+        }
+
+        /// <summary>
+        /// Opens the device.
+        /// </summary>
+        public override void Open(DeviceConfiguration configuration)
+        {
+            // holds errors
+            StringBuilder errbuf = new StringBuilder(Pcap.PCAP_ERRBUF_SIZE);
+
+            var resolution = configuration.TimestampResolution ?? TimestampResolution.Microsecond;
+            PcapHandle adapterHandle;
+            try
+            {
+                adapterHandle = LibPcapSafeNativeMethods.pcap_open_handle_offline_with_tstamp_precision(
+                    FileHandle, (uint)resolution, errbuf);
+            }
+            catch (TypeLoadException ex)
+            {
+                throw new NotSupportedException("libpcap 1.5.0 or higher is required for opening captures by handle", ex);
+            }
+
+            // handle error
+            if (adapterHandle.IsInvalid)
+            {
+                string err = "Unable to open offline adapter: " + errbuf;
+                throw new PcapException(err);
+            }
+
+            // set the device handle
+            Handle = adapterHandle;
+
+            base.Open(configuration);
+        }
+    }
+}
+

--- a/SharpPcap/LibPcap/CaptureReaderDevice.cs
+++ b/SharpPcap/LibPcap/CaptureReaderDevice.cs
@@ -1,0 +1,18 @@
+namespace SharpPcap.LibPcap
+{
+    /// <summary>
+    /// Base class for 'offline' devices.
+    /// </summary>
+    public abstract class CaptureReaderDevice : PcapDevice
+    {
+        /// <summary>
+        /// Retrieves pcap statistics.
+        ///
+        /// Not supported for this device.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="PcapStatistics"/>
+        /// </returns>
+        public override ICaptureStatistics Statistics => null;
+    }
+}

--- a/SharpPcap/LibPcap/LibPcapSafeNativeMethods.Interop.cs
+++ b/SharpPcap/LibPcap/LibPcapSafeNativeMethods.Interop.cs
@@ -485,5 +485,34 @@ namespace SharpPcap.LibPcap
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
         internal extern static int pcap_setmode(PcapHandle /* pcap_t * */ p, int mode);
 
+        /// <summary>
+        /// Windows Only
+        /// Wraps a Pcap handle around an existing OS handle, e.g., a pipe.
+        /// </summary>
+        /// <param name="handle">Native Windows handle.</param>
+        /// <param name="precision">Desired timestamp precision (micro/nano).</param>
+        /// <param name="errbuf">Buffer that will receive an error description if an error occurs.</param>
+        /// <returns></returns>
+        [DllImport(PCAP_DLL, EntryPoint = "pcap_hopen_offline_with_tstamp_precision", CallingConvention = CallingConvention.Cdecl)]
+        internal extern static IntPtr /* pcap_t* */ _pcap_hopen_offline_with_tstamp_precision(
+            SafeHandle handle,
+            uint precision,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(PcapStringMarshaler))] StringBuilder /* char* */ errbuf
+        );
+
+        /// <summary>
+        /// Non-Windows Only
+        /// Wraps a Pcap handle around a C runtime FILE object.
+        /// </summary>
+        /// <param name="fileObject">Pointer to FILE as returned by fopen, etc.</param>
+        /// <param name="precision">Desired timestamp precision (micro/nano).</param>
+        /// <param name="errbuf">Buffer that will receive an error description if an error occurs.</param>
+        /// <returns></returns>
+        [DllImport(PCAP_DLL, EntryPoint = "pcap_fopen_offline_with_tstamp_precision", CallingConvention = CallingConvention.Cdecl)]
+        internal extern static IntPtr /* pcap_t* */ _pcap_fopen_offline_with_tstamp_precision(
+            SafeHandle fileObject,
+            uint precision,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(PcapStringMarshaler))] StringBuilder /* char* */ errbuf
+        );
     }
 }

--- a/SharpPcap/LibPcap/LibPcapSafeNativeMethods.cs
+++ b/SharpPcap/LibPcap/LibPcapSafeNativeMethods.cs
@@ -99,5 +99,26 @@ namespace SharpPcap.LibPcap
         }
 
         #endregion
+
+        /// <summary>
+        /// Wraps a Pcap handle around an existing file handle.
+        /// </summary>
+        /// <param name="handle">Native file handle. On non-Windows systems, this must be a pointer
+        /// to a C runtime <c>FILE</c> object.</param>
+        /// <param name="precision">Desired timestamp precision (micro/nano).</param>
+        /// <param name="errbuf">Buffer that will receive an error description if an error occurs.</param>
+        /// <returns></returns>
+        internal static PcapHandle pcap_open_handle_offline_with_tstamp_precision(
+            SafeHandle handle, uint precision, StringBuilder errbuf)
+        {
+            var pointer = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? _pcap_hopen_offline_with_tstamp_precision(handle, precision, errbuf)
+                : _pcap_fopen_offline_with_tstamp_precision(handle, precision, errbuf);
+            if (pointer == IntPtr.Zero)
+            {
+                return PcapHandle.Invalid;
+            }
+            return new PcapFileHandle(pointer, handle);
+        }
     }
 }

--- a/SharpPcap/LibPcap/PcapDeviceCaptureLoop.cs
+++ b/SharpPcap/LibPcap/PcapDeviceCaptureLoop.cs
@@ -182,7 +182,7 @@ namespace SharpPcap.LibPcap
                                 //       from causing premature exiting from the capture loop we only consider
                                 //       exhausted events to cause an escape from the loop when they are from
                                 //       offline devices, ie. files read from disk
-                                if (this is CaptureFileReaderDevice)
+                                if (this is CaptureReaderDevice)
                                 {
                                     SendCaptureStoppedEvent(CaptureStoppedEventStatus.CompletedWithoutError);
                                     return;

--- a/SharpPcap/LibPcap/PcapHandle.cs
+++ b/SharpPcap/LibPcap/PcapHandle.cs
@@ -21,6 +21,7 @@ along with SharpPcap.  If not, see <http://www.gnu.org/licenses/>.
 
 using Microsoft.Win32.SafeHandles;
 using System;
+using System.Runtime.InteropServices;
 
 namespace SharpPcap.LibPcap
 {
@@ -45,4 +46,33 @@ namespace SharpPcap.LibPcap
 
         internal static readonly PcapHandle Invalid = new PcapHandle(IntPtr.Zero);
     }
+
+    /// <summary>
+    /// Wrapper class that maintains reference to both pcap handle and file handle
+    /// </summary>
+    internal class PcapFileHandle : PcapHandle
+    {
+        private readonly SafeHandle FileHandle;
+
+        public PcapFileHandle(IntPtr pcapHandle, SafeHandle fileHandle)
+        {
+            bool gotRef = false;
+            // The file handle must not be closed by the runtime until the pcap handle is also closed
+            // Incrementing the ref count ensure this
+            fileHandle.DangerousAddRef(ref gotRef);
+            FileHandle = gotRef ? fileHandle : new SafeFileHandle(IntPtr.Zero, false);
+            SetHandle(pcapHandle);
+        }
+
+        // If somehow the file handle became invalid, the pcap handle will also be invalid
+        public override bool IsInvalid => base.IsInvalid || FileHandle.IsInvalid;
+
+        protected override bool ReleaseHandle()
+        {
+            // Closing the pcap handle will also close the file handle
+            FileHandle.SetHandleAsInvalid();
+            return base.ReleaseHandle();
+        }
+    }
+
 }

--- a/Test/CaptureHandleReaderDeviceTest.cs
+++ b/Test/CaptureHandleReaderDeviceTest.cs
@@ -1,0 +1,185 @@
+using System;
+using NUnit.Framework;
+using SharpPcap;
+using SharpPcap.LibPcap;
+using PacketDotNet;
+using System.IO;
+using System.Runtime.InteropServices;
+using Mono.Unix.Native;
+using Microsoft.Win32.SafeHandles;
+
+namespace Test
+{
+    [TestFixture]
+    [LibpcapVersion(">=1.5.0")]
+    public class CaptureHandleReaderDeviceTest
+    {
+        private static int capturedPackets;
+
+        private SafeHandle GetTestFileHandle(string filename)
+        {
+            filename = TestHelper.GetFile(filename);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // On Windows, we need an actual OS handle.
+                // The FileStream is not disposed, which is alright because we take care of its handle.
+                // Once .NET Framework is no longer supported, this can be simplified to File.OpenHandle().
+                return File.Open(filename, FileMode.Open).SafeFileHandle;
+            }
+            // On other platforms, libpcap is not very interop-friendly and expects a FILE*.
+            return new StdlibFileHandle(Stdlib.fopen(filename, "rb"), true);
+        }
+
+        [Category("Timestamp")]
+        [TestCase(TimestampResolution.Nanosecond, "1186341404.189852000s")]
+        [TestCase(TimestampResolution.Microsecond, "1186341404.189852s")]
+        public void CaptureTimestampResolution(TimestampResolution resolution, string timeval)
+        {
+            const string filename = "ipv6_http.pcap";
+            using var handle = GetTestFileHandle(filename);
+            using var device = new CaptureHandleReaderDevice(handle);
+            var configuration = new DeviceConfiguration
+            {
+                TimestampResolution = resolution
+            };
+            device.Open(configuration);
+            Assert.AreEqual(resolution, device.TimestampResolution);
+            device.GetNextPacket(out var packet);
+            Assert.AreEqual(timeval, packet.Header.Timeval.ToString());
+        }
+
+        [Test]
+        public void FileHandleInvalidUponClose()
+        {
+            const string filename = "ipv6_http.pcap";
+            using var handle = GetTestFileHandle(filename);
+            Assert.IsFalse(handle.IsInvalid);
+            Assert.IsFalse(handle.IsClosed);
+            {
+                using var device = new CaptureHandleReaderDevice(handle);
+                device.Open();
+            }
+            Assert.IsTrue(handle.IsClosed);
+        }
+
+        [Test]
+        public void CaptureProperties()
+        {
+            const string filename = "ipv6_http.pcap";
+            using var handle = GetTestFileHandle(filename);
+            using var device = new CaptureHandleReaderDevice(handle);
+            device.Open();
+            Assert.IsNotEmpty(device.Description);
+            Assert.AreEqual(handle, device.FileHandle);
+        }
+
+        /// <summary>
+        /// Test that we can retrieve packets from a pcap file just as we would from
+        /// a live capture device and that all packets are captured
+        /// </summary>
+        [Test]
+        public void CaptureInfinite()
+        {
+            const string filename = "ipv6_http.pcap";
+            using var handle = GetTestFileHandle(filename);
+            using var device = new CaptureHandleReaderDevice(handle);
+            device.OnPacketArrival += HandleDeviceOnPacketArrival;
+            device.Open();
+
+            var expectedPackets = 10;
+            capturedPackets = 0;
+            device.Capture();
+
+            Assert.AreEqual(expectedPackets, capturedPackets);
+        }
+
+        /// <summary>
+        /// Test that if we ask to capture a finite number of packets that
+        /// only this number of packets will be captured
+        /// </summary>
+        [Test]
+        public void CaptureFinite()
+        {
+            const string filename = "ipv6_http.pcap";
+            using var handle = GetTestFileHandle(filename);
+            using var device = new CaptureHandleReaderDevice(handle);
+            device.OnPacketArrival += HandleDeviceOnPacketArrival;
+            device.Open();
+
+            var expectedPackets = 3;
+            capturedPackets = 0;
+            device.Capture(expectedPackets);
+
+            Assert.AreEqual(expectedPackets, capturedPackets);
+        }
+
+        void HandleDeviceOnPacketArrival(object sender, PacketCapture e)
+        {
+            Console.WriteLine("got packet " + e.GetPacket().ToString());
+            capturedPackets++;
+        }
+
+        /// <summary>
+        /// Test that we get expected unsupport indication when attempting to retrieve
+        /// Statistics from this device
+        /// </summary>
+        [Test]
+        public void StatisticsUnsupported()
+        {
+            const string filename = "ipv6_http.pcap";
+            using var handle = GetTestFileHandle(filename);
+            using var device = new CaptureHandleReaderDevice(handle);
+            device.Open();
+            Assert.IsNull(device.Statistics);
+        }
+
+        [Test]
+        public void SetFilter()
+        {
+            const string filename = "test_stream.pcap";
+            using var handle = GetTestFileHandle(filename);
+            using var device = new CaptureHandleReaderDevice(handle);
+
+            device.Open();
+            device.Filter = "port 53";
+
+            RawCapture rawPacket;
+            int count = 0;
+            PacketCapture e;
+            GetPacketStatus retval;
+            do
+            {
+                retval = device.GetNextPacket(out e);
+                if (retval == GetPacketStatus.PacketRead)
+                {
+                    rawPacket = e.GetPacket();
+                    Packet p = Packet.ParsePacket(rawPacket.LinkLayerType, rawPacket.Data);
+                    var udpPacket = p.Extract<UdpPacket>();
+                    Assert.IsNotNull(udpPacket);
+                    int dnsPort = 53;
+                    Assert.AreEqual(dnsPort, udpPacket.DestinationPort);
+                    count++;
+                }
+            } while (retval == GetPacketStatus.PacketRead);
+
+            Assert.AreEqual(1, count);
+        }
+    }
+
+
+    internal class StdlibFileHandle : SafeHandleZeroOrMinusOneIsInvalid
+    {
+        public StdlibFileHandle(IntPtr preexistingHandle, bool ownsHandle)
+            : base(ownsHandle)
+        {
+            SetHandle(preexistingHandle);
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            return Stdlib.fclose(handle) == 0;
+        }
+
+    }
+
+}

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -11,6 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Mono.Posix" Version="7.1.0-final.1.21458.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />


### PR DESCRIPTION
Add a CaptureHandleReaderDevice that can be instantiated with an existing file handle. This is advantageous in situations where one would like fine-grained control over how the handle is opened.