### PR TITLE
Support statically linked NativeAOT distribution

### DIFF
--- a/SharpPcap/LibPcap/BpfProgram.cs
+++ b/SharpPcap/LibPcap/BpfProgram.cs
@@ -34,7 +34,12 @@ namespace SharpPcap.LibPcap
         // Requires calls to pcap_compile to be non-concurrent to avoid crashes due to known lack of thread-safety
         // See https://github.com/chmorgan/sharppcap/issues/311
         // Problem of thread safety does not affect Windows
-        private static readonly bool ThreadSafeCompile = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+        private static readonly bool ThreadSafeCompile =
+#if NET6_0_OR_GREATER
+            OperatingSystem.IsWindows()
+#else
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+#endif
             || Pcap.LibpcapVersion >= new Version(1, 8, 0);
         private static readonly object SyncCompile = new object();
 

--- a/SharpPcap/LibPcap/LibPcapSafeNativeMethods.Encoding.cs
+++ b/SharpPcap/LibPcap/LibPcapSafeNativeMethods.Encoding.cs
@@ -37,7 +37,13 @@ namespace SharpPcap.LibPcap
 
         private static Encoding ConfigureStringEncoding()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (!
+#if NET6_0_OR_GREATER
+            OperatingSystem.IsWindows()
+#else
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+#endif
+            )
             {
                 // libpcap always use UTF-8 when not on Windows
                 return Encoding.UTF8;

--- a/SharpPcap/LibPcap/LibPcapSafeNativeMethods.Interop.cs
+++ b/SharpPcap/LibPcap/LibPcapSafeNativeMethods.Interop.cs
@@ -41,7 +41,7 @@ namespace SharpPcap.LibPcap
         //       This file is called $assembly_name.dll.config and is placed in the
         //       same directory as the assembly
         //       See http://www.mono-project.com/Interop_with_Native_Libraries#Library_Names
-        private const string PCAP_DLL = "wpcap";
+        private const string PCAP_DLL = "pcap";
 
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
         internal extern static int pcap_init(
@@ -66,13 +66,15 @@ namespace SharpPcap.LibPcap
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
         internal extern static void pcap_freealldevs(IntPtr /* pcap_if_t * */ alldevs);
 
+        /// <summary>
+        /// Open a generic source in order to capture / send (WinPcap only) traffic.
+        /// </summary>
         [DllImport(PCAP_DLL, CallingConvention = CallingConvention.Cdecl)]
-        internal extern static PcapHandle /* pcap_t* */ pcap_open(
+        internal extern static PcapHandle /* pcap_t* */ pcap_open_live(
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(PcapStringMarshaler))] string dev,
-            int packetLen,
-            int flags,
-            int read_timeout,
-            ref pcap_rmtauth rmtauth,
+            int snaplen,
+            int promisc,
+            int to_ms,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(PcapStringMarshaler))] StringBuilder errbuf
         );
 

--- a/SharpPcap/LibPcap/LibPcapSafeNativeMethods.Resolver.cs
+++ b/SharpPcap/LibPcap/LibPcapSafeNativeMethods.Resolver.cs
@@ -39,7 +39,13 @@ namespace SharpPcap.LibPcap
 
         static LibPcapSafeNativeMethods()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (
+#if NET6_0_OR_GREATER
+            OperatingSystem.IsWindows()
+#else
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+#endif
+            )
             {
                 SetDllDirectory(Path.Combine(Environment.SystemDirectory, "Npcap"));
             }
@@ -70,7 +76,13 @@ namespace SharpPcap.LibPcap
 
             var names = new List<string>();
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            if (
+#if NET6_0_OR_GREATER
+            OperatingSystem.IsLinux()
+#else
+            RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+#endif
+            )
             {
                 names.Add("libpcap.so");
                 names.Add("libpcap.so.0");
@@ -78,7 +90,13 @@ namespace SharpPcap.LibPcap
                 names.Add("libpcap.so.1");
             }
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            if (
+#if NET6_0_OR_GREATER
+            OperatingSystem.IsMacOS()
+#else
+            RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+#endif
+            )
             {
                 names.Add("libpcap.dylib");
             }

--- a/SharpPcap/LibPcap/LibPcapSafeNativeMethods.cs
+++ b/SharpPcap/LibPcap/LibPcapSafeNativeMethods.cs
@@ -37,13 +37,23 @@ namespace SharpPcap.LibPcap
 
         internal static PcapError pcap_setbuff(PcapHandle /* pcap_t */ adapter, int bufferSizeInBytes)
         {
-            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            return
+#if NET6_0_OR_GREATER
+            OperatingSystem.IsWindows()
+#else
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+# endif
                 ? _pcap_setbuff(adapter, bufferSizeInBytes)
                 : PcapError.PlatformNotSupported;
         }
         internal static PcapError pcap_setmintocopy(PcapHandle /* pcap_t */ adapter, int sizeInBytes)
         {
-            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            return
+#if NET6_0_OR_GREATER
+            OperatingSystem.IsWindows()
+#else
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+#endif
                 ? _pcap_setmintocopy(adapter, sizeInBytes)
                 : PcapError.PlatformNotSupported;
         }
@@ -111,7 +121,12 @@ namespace SharpPcap.LibPcap
         internal static PcapHandle pcap_open_handle_offline_with_tstamp_precision(
             SafeHandle handle, uint precision, StringBuilder errbuf)
         {
-            var pointer = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            var pointer =
+#if NET6_0_OR_GREATER
+            OperatingSystem.IsWindows()
+#else
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+# endif
                 ? _pcap_hopen_offline_with_tstamp_precision(handle, precision, errbuf)
                 : _pcap_fopen_offline_with_tstamp_precision(handle, precision, errbuf);
             if (pointer == IntPtr.Zero)

--- a/SharpPcap/LibPcap/PcapHeader.cs
+++ b/SharpPcap/LibPcap/PcapHeader.cs
@@ -30,8 +30,20 @@ namespace SharpPcap.LibPcap
     /// </summary>
     public class PcapHeader : ICaptureHeader
     {
-        private static readonly bool isMacOSX = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
-        private static readonly bool is32BitTs = IntPtr.Size == 4 || RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        private static readonly bool isMacOSX =
+#if NET6_0_OR_GREATER
+            OperatingSystem.IsMacOS()
+#else
+            RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+#endif
+            ;
+        private static readonly bool is32BitTs = IntPtr.Size == 4 ||
+#if NET6_0_OR_GREATER
+            OperatingSystem.IsWindows()
+#else
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+#endif
+            ;
 
         internal static readonly int MemorySize = GetTimevalSize() + sizeof(uint) + sizeof(uint);
 

--- a/SharpPcap/LibPcap/PcapInterface.cs
+++ b/SharpPcap/LibPcap/PcapInterface.cs
@@ -143,7 +143,13 @@ namespace SharpPcap.LibPcap
                     }
                 }
             }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            else if (
+#if NET6_0_OR_GREATER
+            OperatingSystem.IsWindows()
+#else
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+#endif
+            )
             {
                 FriendlyName = WindowsNativeMethods.GetInterfaceAlias(Name);
             }

--- a/SharpPcap/Pcap.cs
+++ b/SharpPcap/Pcap.cs
@@ -108,7 +108,13 @@ namespace SharpPcap
             // FIXME: need to resolve the discrepency at some point
             AF_PACKET = 17;
 
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (!
+#if NET6_0_OR_GREATER
+            OperatingSystem.IsWindows()
+#else
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+#endif
+            )
             {
                 AF_INET6 = 10; // value for linux from socket.h
             }

--- a/SharpPcap/SharpPcap.csproj
+++ b/SharpPcap/SharpPcap.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <Version>6.2.5</Version>
     <Description>A packet capture framework for .NET</Description>
     <Authors>Tamir Gal, Chris Morgan and others</Authors>

--- a/SharpPcap/Statistics/StatisticsDevice.cs
+++ b/SharpPcap/Statistics/StatisticsDevice.cs
@@ -33,7 +33,13 @@ namespace SharpPcap.Statistics
     {
         private readonly LibPcapLiveDevice LiveDevice;
 
-        private static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        private static readonly bool IsWindows =
+#if NET6_0_OR_GREATER
+            OperatingSystem.IsWindows()
+#else
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+#endif
+            ;
 
         /// <summary>
         /// Constructs a new PcapDevice based on a 'pcapIf' struct

--- a/SharpPcap/Tunneling/TunnelDevice.cs
+++ b/SharpPcap/Tunneling/TunnelDevice.cs
@@ -18,7 +18,13 @@ namespace SharpPcap.Tunneling
 
         private static ITunnelDriver GetDriver()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (
+#if NET6_0_OR_GREATER
+            OperatingSystem.IsWindows()
+#else
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+#endif
+            )
             {
                 return WinTapDriver.Instance;
             }


### PR DESCRIPTION
- Use `SystemOperating` APIs on .NET 6+. The NativeAOT compiler can remove all branches that don't fit target operating system, so Windows specific APIs won't be linked on Linux platform.
- Use `pcap` instead of `wpcap`