### PR TITLE
Add CancellationToken support.

### DIFF
--- a/SharpPcap/LibPcap/SendQueue.cs
+++ b/SharpPcap/LibPcap/SendQueue.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2005 Tamir Gal <tamir@tamirgal.com>
 // Copyright 2008-2009 Chris Morgan <chmorgan@gmail.com>
- Transmit
-
-//
+ //
 // SPDX-License-Identifier: MIT
 
 using PacketDotNet;

--- a/Test/SendQueueTest.cs
+++ b/Test/SendQueueTest.cs
@@ -13,6 +13,7 @@ using static Test.TestHelper;
 using static System.TimeSpan;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Net.NetworkInformation;
 
 namespace Test
 {
@@ -312,19 +313,22 @@ namespace Test
         {
             var queue = new SendQueue(1024*1024*64);
             int packages = 0;
-            while (queue.Add(Packet.RandomPacket()))
+            while (queue.Add(EthernetPacket.RandomPacket()))
             {
                 packages++;
             }
             var canceller = new CancellationTokenSource();
             int packagesSent = 0;
+            using (var testInterface = TestHelper.GetPcapDevice())
+            {
+                testInterface.Open();
             var snd = new Task(() => { packagesSent = queue.Transmit(testInterface, false, canceller.Token); } );
             snd.Start();
             Thread.Sleep(100);
             canceller.Cancel();
             snd.Wait();
-            Assert.That(packagesSent < packages))
-            Assert.Fail("Not implemented yet.");
+            }
+            Assert.That(packagesSent < packages);
         }
     }
 }


### PR DESCRIPTION
In some cases, especially continous or burst send applications or network reactivity tests it may come in handy to be able to cancel an ongoing transmission. For this reason additional functionality and logic supporting .NET CancellationToken functionality has been implemented . Since the native methods do not (and maybe cannot) support this only managed transmission is used when using a cancellation token, regardless whether HW acceleration is available.