### PR TITLE
Update README to specify GetPacket not Packet

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ See the [Examples](https://github.com/chmorgan/sharppcap/tree/master/Examples) f
    ```cs
    void Device_OnPacketArrival(object s, PacketCapture e)
    {
-       Console.WriteLine(e.Packet);
+       Console.WriteLine(e.GetPacket());
    }
 
    using var device = LibPcapLiveDeviceList.Instance[0];
@@ -86,7 +86,7 @@ See the [Examples](https://github.com/chmorgan/sharppcap/tree/master/Examples) f
    ```cs
    void Device_OnPacketArrival(object s, PacketCapture e)
    {
-       Console.WriteLine(e.Packet);
+       Console.WriteLine(e.GetPacket());
    }
 
    using var device = new CaptureFileReaderDevice("filename.pcap");


### PR DESCRIPTION
Update the examples found in the README. PacketCapture does not have a field or property `Packet` but a method `GetPacket`.