### PR TITLE
Remove duplicate nuget packages in SharpPcap csproj

### DIFF
--- a/SharpPcap/SharpPcap.csproj
+++ b/SharpPcap/SharpPcap.csproj
@@ -31,7 +31,7 @@ SPDX-License-Identifier: MIT
   <ItemGroup>
     <PackageReference Include="PacketDotNet" Version="1.4.7" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
   </ItemGroup>
   <ItemGroup>

--- a/SharpPcap/SharpPcap.csproj
+++ b/SharpPcap/SharpPcap.csproj
@@ -33,8 +33,6 @@ SPDX-License-Identifier: MIT
     <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">


### PR DESCRIPTION
Noticed that SharpPcap had duplicate NuGet packages, possibly they came about after a merge or rebase? Figured it was best to remove them.