### PR TITLE
Set FlagsAttribute on WinDivertPacketFlags

### DIFF
--- a/SharpPcap/WinDivert/WinDivertPacketFlags.cs
+++ b/SharpPcap/WinDivert/WinDivertPacketFlags.cs
@@ -2,8 +2,11 @@
 //
 // SPDX-License-Identifier: MIT
 
+using System;
+
 namespace SharpPcap.WinDivert
 {
+    [Flags]
     public enum WinDivertPacketFlags : byte
     {
         Sniffed = 1 << 0,


### PR DESCRIPTION
```
var x = (WinDivertPacketFlags)167;
Console.WriteLine(x.ToString());
```

Before this change:
```
167
```

After this change
```
Sniffed, Outbound, Loopback, IPChecksum, UDPChecksum
```

This is particularly useful in a debugger. 

Also, it fixes that ReSharper warning
![image](https://github.com/user-attachments/assets/cc2bf0c0-e992-497c-8776-aa6e4afee006)