### PR TITLE
remove never used comment

### DIFF
--- a/SharpPcap/LibPcap/LibPcapSafeNativeMethods.Encoding.cs
+++ b/SharpPcap/LibPcap/LibPcapSafeNativeMethods.Encoding.cs
@@ -91,8 +91,6 @@ namespace SharpPcap.LibPcap
                 }
                 var str = (string)managedObj;
                 var bytes = StringEncoding.GetBytes(str);
-                // The problem is that we need a reference to the StringBuilder in MarshalNativeToManaged
-                // So we get a pointer to it with GCHandle, and put it as prefix of the pointer we return
                 var ptr = Marshal.AllocHGlobal(bytes.Length + 1);
                 Marshal.Copy(bytes, 0, ptr, bytes.Length);
                 // Put zero string termination


### PR DESCRIPTION
By fixing errbuf returning something, it was missed on several rewrites that the comment was still inside.